### PR TITLE
Adding url param on load

### DIFF
--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -1,7 +1,15 @@
 var handleClick = function (el) {
   decorateSidebar(el);
   showMainContent(el);
+  updateLocation(el);
   if (menuIsVisible()) handleMenuClick();
+}
+
+var updateLocation = function (el) {
+  let loc = el.parentElement.id.split("-")[1];
+  if (loc) {
+    window.history.pushState(loc, '', `?l=${loc}`);
+  }
 }
 
 var decorateSidebar = function (el) {

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -45,3 +45,12 @@ var handleJiraSearch = function () {
   let searchTerms = document.getElementById("jira-search").value;
   window.open(`https://issues.apache.org/jira/browse/AGE-1?jql=(project%3DAGE)%20and%20text%20~%20%22${searchTerms}%22`, "_blank");
 }
+
+window.onload = function() {
+  let url = new URL(location.href);
+  let goto = url.searchParams.get("l");
+  let el = document.getElementById(`sidebar-${goto}`);
+  if (el) {
+    handleClick(el.firstChild);
+  }
+}


### PR DESCRIPTION
This change allows users to link based on the span items IDs in the sidebar. For example, given these spans:

``` 
<span id="sidebar-overview" class="sidebar-item sidebar--selected"> <a class="sidebar-link" href="#" onclick="handleClick(this)">Overview</a></span> <br />
<span id="sidebar-license" class="sidebar-item"> <a class="sidebar-link" href="#" onclick="handleClick(this)">License</a></span> <br />
<span id="sidebar-roadmap" class="sidebar-item"> <a class="sidebar-link" href="#sidebar-roadmap" onclick="handleClick(this)">Roadmap</a></span> <br />
```
The following links could be given out:
https://age.apache.org/?l=overview
https://age.apache.org/?l=license
https://age.apache.org/?l=roadmap